### PR TITLE
set the dateformat to include utc offset in saved bars by default

### DIFF
--- a/src/download_bars.py
+++ b/src/download_bars.py
@@ -64,11 +64,11 @@ class DownloadApp(EClient, ibapi.wrapper.EWrapper):
         self.useRTH = args.useRTH
         self.queue = Queue()
 
-    def send_done(self, code):
+    def send_done(self, code: int) -> None:
         logging.info("Sending code %s", code)
         self.queue.put(code)
 
-    def wait_done(self):
+    def wait_done(self) -> None:
         logging.info("Waiting for thread to finish ...")
         code = self.queue.get()
         logging.info("Received code %s", code)
@@ -455,7 +455,10 @@ def main():
         "--timezone", type=str, help="Timezone for requests", default="UTC"
     )
     argp.add_argument(
-        "--date-format", type=str, help="Date format for output csvs", default="%Y-%m-%d %H:%M:%S"
+        "--date-format",
+        type=str,
+        help="Date format for output csvs. Should include %z for utc offset",
+        default="%Y-%m-%d %H:%M:%S%z",
     )
     argp.add_argument(
         "--start-date",
@@ -502,8 +505,12 @@ def main():
         sys.exit(1)
 
     tz = pytz.timezone(args.timezone)
-    args.start_date = tz.localize(args.start_date)
-    args.end_date = tz.localize(args.end_date)
+    args.start_date = tz.localize(args.start_date).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    args.end_date = tz.localize(args.end_date).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
     logging.debug(f"args={args}")
     contracts = []
     for s in args.symbol:


### PR DESCRIPTION
When users run the script, the first time it saves data it applies a timezone to the resulting data ok if the dateformat includes %Z. But if the file is reopened and merged on another run, the timezone name is missing, so %Z doesn't work. Using %z will persist across multiple reads and writes.

In reality, data should be stored with a utc timestamp and converted to local time in another way, but this change should at least allow the defaults to work better.